### PR TITLE
fix #1507: nx build affected issue in GH workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,5 +70,5 @@ jobs:
           # https://stackoverflow.com/a/73429959/1975086, https://github.com/angular/angular/issues/38216
           BAZEL_TARGET: "1"
         # https://stackoverflow.com/questions/73876647/using-nx-run-many-shows-another-process-with-id-is-currently-running-ngcc
-        run: pnpm run nx affected --target=build --base=${{ env.NX_BASE }} --parallel=0 --maxParallel=1
+        run: pnpm run nx affected --target=build --base=${{ env.NX_BASE }} 
 #        working-directory: ./src


### PR DESCRIPTION
This pull request addresses an issue where the NX build did not fail in the GH workflow, but it did locally due to the incompatibility of Angular 16 with TS 5.5.2.

To resolve this issue, I made the following changes to the `build.yml` file:
- Removed the `parallel` and `maxParallel` optional arguments.
- The default value of `parallel` is 3, but it was erroneously set to 0, resulting in no concurrency.
- Additionally, `maxParallel` was not a valid option and has been removed.

These changes ensure that the build will now fail in the GH workflow and maintain compatibility with Angular 16.

Please refer to the related issue for more information: [Issue #1507](https://github.com/sneat-co/sneat-apps/issues/1507)