### PR TITLE
fix(ci): Install PNPM without warnings re Node20

### DIFF
--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -18,10 +18,13 @@ runs:
                 node-version: '20'
 
         -   name: Install PNPM
-            uses: pnpm/action-setup@v2
-            with:
-                version: 8
-                run_install: false
+            shell: sh
+            run: npm install pnpm@8 -g
+#            uses: pnpm/action-setup@v2
+#            with:
+#                version: 8
+#                run_install: false
+
 
         -   run: pnpm --version
             shell: sh


### PR DESCRIPTION
A workaround for https://github.com/pnpm/action-setup/issues/99